### PR TITLE
Corrected README.md. The use of the Convert Locator to Browser keyword is no longer necessary and supported.

### DIFF
--- a/Playwright-page-methods/README.md
+++ b/Playwright-page-methods/README.md
@@ -28,8 +28,7 @@ Native Playwright
     Playwright Page Method    getByLabel('Search').click()
     Playwright Page Method    getByLabel('Search').nth(1).type('locators')
     ${pw_locator}    Playwright Page Method    getByRole('link', { name: 'FrameLocator' })
-    ${clickme}       Convert Locator To Browser    playwright_locator=${pw_locator}
-    Click            ${clickme}
+    Click    ${pw_locator}
     Sleep    3s
 
 Playwright Assertions


### PR DESCRIPTION
Corrected the example code in the README.md. The use of the Convert Locator to Browser keyword is no longer necessary and supported and therefore removed.