### PR TITLE
Argument validation implemented

### DIFF
--- a/mockUrl/mockUrl.js
+++ b/mockUrl/mockUrl.js
@@ -36,6 +36,12 @@ async function mockUrl(args, page, logger) {
   }
 }
 
+mockUrl.rfdoc = `
+    Keyword adds a mock response to any request browser makes.
+    = Argument information =
+    - \`mockData\`  single or list of dictionaries containing following members: \`url\`,  \`statusCode\`, \`contentType\` & \`body\`. All arguments are required
+`
+
 async function blockUrl(args, page, logger) {
   for (const arg of args) {
     _checkProperties(["url"], arg)
@@ -49,6 +55,12 @@ async function blockUrl(args, page, logger) {
   }
 }
 
+blockUrl.rfdoc = `
+    Keyword sets up a browser to prevent network requests from being sent.
+    = Argument information =
+    - \`blockData\`  single or list of dictionaries containing following members \`url\` & \`errorCode\` where \`errorCode\` is optional and defaults to \`failed\` if not provided.\nCurrently supported errorCodes: \`aborted\`, \`accessdenied\`, \`addressunreachable\`, \`blockedbyclient\`, \`blockedbyresponse\`, \`connectionaborted\`, \`connectionclosed\`, \`connectionfailed\`, \`connectionrefused\`, \`connectionreset\`, \`internetdisconnected\`, \`namenotresolved\` and \`timedout\` and  \`failed\`
+`
+
 async function RecordHAR(args, page, logger, playwright) {
   for (const arg of args) {
     _checkProperties(["url", "har"], arg)
@@ -61,6 +73,11 @@ async function RecordHAR(args, page, logger, playwright) {
   }
 }
 
+RecordHAR.rfdoc = `
+    Keyword records network requests to provided HAR file.
+    = Argument information =
+    - \`harData\`  single or list of dictionaries containing following members \`url\` & \`har\` where \`har\` is the path to HAR file where recorded data is stored.
+`
 
 async function MockWithHar(args, page, logger, playwright) {
   for (const arg of args) {
@@ -72,6 +89,13 @@ async function MockWithHar(args, page, logger, playwright) {
     });
   }
 }
+
+MockWithHar.rfdoc = `
+    Keyword sets up mocked requests from provided HAR file.
+    = Argument information =
+    - \`harData\`  single or list of dictionaries containing following members \`url\` & \`har\` where \`har\` is the path to HAR file thats used to setup mocked responses.
+`
+
 
 
 exports.__esModule = true;

--- a/mockUrl/mockUrl.js
+++ b/mockUrl/mockUrl.js
@@ -1,5 +1,31 @@
+const _errorCodes = [
+  'aborted',
+  'accessdenied',
+  'addressunreachable',
+  'blockedbyclient',
+  'blockedbyresponse',
+  'connectionaborted',
+  'connectionclosed',
+  'connectionfailed',
+  'connectionrefused',
+  'connectionreset',
+  'internetdisconnected',
+  'namenotresolved',
+  'timedout',
+  'failed']
+
+
+function _checkProperties(requiredProps, obj) {
+  for (const prop of requiredProps) {
+    if (Object.hasOwn(obj, prop) == false) {
+      throw Error(`Provided argument object doesnt have required property ${prop}`)
+    }
+  }
+}
+
 async function mockUrl(args, page, logger) {
   for (const arg of args) {
+    _checkProperties(["url", "statusCode", "contentType", "body"], arg)
     await page.route(String(arg.url), route => {
       route.fulfill({
         status: parseInt(arg.statusCode, 10),
@@ -12,14 +38,20 @@ async function mockUrl(args, page, logger) {
 
 async function blockUrl(args, page, logger) {
   for (const arg of args) {
-    await page.route(String(arg.url), route => {
-      route.abort(arg.errorCode || 'failed');
-    });
+    _checkProperties(["url"], arg)
+    if (_errorCodes.includes(arg.errorCode) || arg.errorCode === undefined || arg.errorCode === null) {
+      await page.route(String(arg.url), route => {
+        route.abort(arg.errorCode || 'failed');
+      });
+    } else {
+      throw Error(`Provided errorCode ${arg.errorCode} is not valid errorcode.\nSee: https://playwright.dev/docs/api/class-route#route-abort-option-error-code `)
+    }
   }
 }
 
 async function RecordHAR(args, page, logger, playwright) {
   for (const arg of args) {
+    _checkProperties(["url", "har"], arg)
     await page.routeFromHAR(arg.har, {
       url: arg.url,
       update: true,
@@ -32,6 +64,7 @@ async function RecordHAR(args, page, logger, playwright) {
 
 async function MockWithHar(args, page, logger, playwright) {
   for (const arg of args) {
+    _checkProperties(["url", "har"], arg)
     await page.routeFromHAR(arg.har, {
       url: arg.url,
       update: false,


### PR DESCRIPTION
* checks if errorCode for route.abort is valid, otherwise playwright crashes
* checks that all required arguments are passed into keywords.

Fixes:  #27